### PR TITLE
add support for ESLint

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,29 @@
+{
+  "env": {
+    "node": true
+  },
+  "extends": "eslint:recommended",
+  "rules": {
+    "array-callback-return": "warn",
+    "brace-style": ["error", "1tbs"],
+    "complexity": ["warn", 20],
+    "eqeqeq": "error",
+    "guard-for-in": "error",
+    "indent": ["error", 2],
+    "linebreak-style": ["error", "unix"],
+    "no-array-constructor": "error",
+    "no-console": "warn",
+    "no-lonely-if": "warn",
+    "no-loop-func": "warn",
+    "no-mixed-spaces-and-tabs": ["error"],
+    "no-nested-ternary": "error",
+    "no-spaced-func": "error",
+    "no-trailing-spaces": "error",
+    "semi": ["error", "always"],
+    "space-before-blocks": "error",
+    "space-before-function-paren": ["error", "never"],
+    "keyword-spacing": ["error"],
+    "curly": ["error", "all"]
+  }
+}
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,3 +8,5 @@ before_install:
   - npm install -g grunt@0.4.5
   - npm install -g grunt-cli
 install: npm install
+script:
+  - npm run-script eslint

--- a/package.json
+++ b/package.json
@@ -3,6 +3,10 @@
   "version": "0.0.14",
   "description": "An implementation of the mediator pattern for use with WFM",
   "main": "lib/angular/mediator-ng.js",
+  "scripts": {
+    "eslint": "eslint lib/",
+    "eslint-fix": "eslint --fix lib/"
+  },
   "keywords": [
     "wfm",
     "mediator"
@@ -14,5 +18,8 @@
     "mediator-js": "^0.9.9",
     "q": "^1.4.1",
     "shortid": "^2.2.6"
+  },
+  "devDependencies": {
+    "eslint": "^3.6.1"
   }
 }


### PR DESCRIPTION
Motivation:
Add support for ESLint

Modifications:
Added eslint as a dev dependency, and added two scripts to execute
eslint.

Also added eslint to be run as by Travis (CI).

Result:
Is not possible to run eslint using:
```
$ npm run-script eslint
```
and fix issues by running:
```
$npm run-script eslint-fix
```
JIRA:
https://issues.jboss.org/browse/RHMAP-5711