### PR TITLE
Update module name to raincatcher-mediator

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ This module is packaged in a CommonJS format, exporting the name of the Angular 
 
 ```javascript
 angular.module('app', [
-, require('fh-wfm-mediator')
+, require('raincatcher-mediator')
 ...
 ])
 ```
@@ -44,5 +44,5 @@ Inject the `mediator` service to broadcast and subscribe to events
 Require the module to get an instance of the mediator.  Be sure to use that same instance throughout the application to maintain a single list of subscribers.
 
 ```javascript
-mediator = require('fh-wfm-mediator/lib/mediator')
+mediator = require('raincatcher-mediator/lib/mediator')
 ```

--- a/package.json
+++ b/package.json
@@ -1,13 +1,13 @@
 {
-  "name": "fh-wfm-mediator",
+  "name": "raincatcher-mediator",
   "version": "0.0.14",
-  "description": "An implementation of the mediator pattern for use with WFM",
+  "description": "An implementation of the mediator pattern for use with Raincatcher",
   "main": "lib/angular/mediator-ng.js",
   "scripts": {
     "test": "grunt"
   },
   "keywords": [
-    "wfm",
+    "raincatcher",
     "mediator"
   ],
   "author": "Brian Leathem",


### PR DESCRIPTION
Motivation:
Currently this project's module name is named after the old Work
Force Management (WFM) which has changed to Raincatcher. But the npm
module names have not been updated which is that this commit does.

Modifications:
Updated the module name in package.json and updated README.md to
reflect the module change.

JIRA:
https://issues.jboss.org/browse/RAINCATCH-231
