### PR TITLE
Remove q in favor of bluebird

### DIFF
--- a/lib/mediator.js
+++ b/lib/mediator.js
@@ -18,6 +18,32 @@ Mediator.prototype.promise = function(channel, options, context) {
   });
 };
 
+/**
+ * Publishes a message on a topic and wait for a response or error
+ *
+ * By convention 'return' topics are prefixed with 'done:' and 'error:' to signal
+ * the result of the operation, and suffixed with a unique id to map clients in
+ * order to supply the results to the correct client.
+ *
+ * @param  {String} topic      Channel identifier to publish the initial message
+ *
+ * @param  {Any} parameters    The data to publish to the topic. The unique id used to publish
+ *                             the 'return' topic is extracted from this parameter according to
+ *                             the following rules:
+ *                             - `parameters.id` property, If parameters has this property
+ *                             - `parameters[0]` if parameters is an Array
+ *                             - `parameters.toString()` otherwise
+ *
+ * @param  {Object} options    Options object
+ * @param  {String} options.uid  Overrides the unique id from the {@link parameters}
+ * @param  {String} options.doneTopic  Base topic to subscribe for the result of the request,
+ *                               gets prefixed with 'done:'
+ * @param  {String} options.errorTopic  Base topic to subscribe for errors on the request,
+ *                               gets prefixed with 'error:'
+ *
+ * @return {Promise}           A Promise that gets fulfilled with the result of the request
+ *                               or rejected with the error from the above topics
+ */
 Mediator.prototype.request = function(topic, parameters, options) {
   var self = this;
   options = options || {};
@@ -32,7 +58,11 @@ Mediator.prototype.request = function(topic, parameters, options) {
   if (_.has(options, 'uid')) {
     uid = options.uid;
   } else if (typeof parameters !== "undefined" && parameters !== null) {
-    uid = parameters instanceof Array ? parameters[0] : parameters;
+    if (_.has(parameters, 'id')) {
+      uid = parameters.id;
+    } else {
+      uid = parameters instanceof Array ? parameters[0] : parameters.toString();
+    }
   }
 
   if (uid !== null) {

--- a/lib/mediator.js
+++ b/lib/mediator.js
@@ -4,21 +4,22 @@ var _ = require('lodash');
 var Mediator = require('mediator-js').Mediator;
 var Promise = require('bluebird');
 
-var mediator = new Mediator();
 
 /**
- * A version of {@link once} that returns a promise
+ * A version of {@link once} that returns a Promise
  * @param  {String} channel   Channel identifier to wait on a single message
  * @return {Promise}          A promise that is fulfilled with the next published
  *                             message in the channel
  */
-mediator.promise = function(channel, options, context) {
+Mediator.prototype.promise = function(channel, options, context) {
+  var self = this;
   return new Promise(function(resolve) {
-    mediator.once(channel, resolve, options, context);
+    self.once(channel, resolve, options, context);
   });
 };
 
-mediator.request = function(topic, parameters, options) {
+Mediator.prototype.request = function(topic, parameters, options) {
+  var self = this;
   options = options || {};
   var topics = {
     request: topic,
@@ -44,8 +45,8 @@ mediator.request = function(topic, parameters, options) {
   }
 
   function unsubscribe() {
-    mediator.remove(topics.done, subs.done.id);
-    mediator.remove(topics.error, subs.error.id);
+    self.remove(topics.done, subs.done.id);
+    self.remove(topics.error, subs.error.id);
   }
 
   var args = [topics.request];
@@ -54,10 +55,10 @@ mediator.request = function(topic, parameters, options) {
   } else {
     args.push(parameters);
   }
-  mediator.publish.apply(mediator, args);
+  self.publish.apply(mediator, args);
 
   return new Promise(function(resolve, reject) {
-    subs.done = mediator.once(topics.done, resolve);
+    subs.done = self.once(topics.done, resolve);
     subs.error = mediator.once(topics.error, reject);
   })
   .timeout(options.timeout, new Error('Mediator request timeout for topic ' +  topic))
@@ -69,4 +70,6 @@ mediator.request = function(topic, parameters, options) {
   });
 };
 
+var mediator = new Mediator();
+mediator.Mediator = Mediator;
 module.exports = mediator;

--- a/lib/mediator.js
+++ b/lib/mediator.js
@@ -2,30 +2,30 @@
 
 var _ = require('lodash');
 var Mediator = require('mediator-js').Mediator;
-var q = require('q');
+var Promise = require('bluebird');
 
 var mediator = new Mediator();
 
-mediator.promise = function() {
-  var deferred = q.defer();
-  var cb = function(data) {
-    deferred.resolve(data);
-  };
-  var args = [];
-  Array.prototype.push.apply(args, arguments);
-  args.splice(1, 0, cb);
-  mediator.once.apply(mediator, args);
-  return deferred.promise;
+/**
+ * A version of {@link once} that returns a promise
+ * @param  {String} channel   Channel identifier to wait on a single message
+ * @return {Promise}          A promise that is fulfilled with the next published
+ *                             message in the channel
+ */
+mediator.promise = function(channel, options, context) {
+  return new Promise(function(resolve) {
+    mediator.once(channel, resolve, options, context);
+  });
 };
 
 mediator.request = function(topic, parameters, options) {
-  var topics = {}, subs = {}, complete = false, timeout;
-  var deferred = q.defer();
   options = options || {};
-
-  topics.request = topic;
-  topics.done = options.doneTopic || 'done:' + topic;
-  topics.error = options.errorTopic || 'error:' + topic;
+  var topics = {
+    request: topic,
+    done: options.doneTopic || 'done:' + topic,
+    error: options.errorTopic || 'error:' + topic
+  };
+  var subs = {};
 
   var uid = null;
   if (_.has(options, 'uid')) {
@@ -43,22 +43,10 @@ mediator.request = function(topic, parameters, options) {
     options.timeout = 2000;
   }
 
-  var cleanUp = function() {
-    complete = true;
-    clearTimeout(timeout);
+  function unsubscribe() {
     mediator.remove(topics.done, subs.done.id);
     mediator.remove(topics.error, subs.error.id);
-  };
-
-  subs.done = mediator.subscribe(topics.done, function(result) {
-    cleanUp();
-    deferred.resolve(result);
-  });
-
-  subs.error = mediator.subscribe(topics.error, function(error) {
-    cleanUp();
-    deferred.reject(error);
-  });
+  }
 
   var args = [topics.request];
   if (parameters instanceof Array) {
@@ -68,14 +56,17 @@ mediator.request = function(topic, parameters, options) {
   }
   mediator.publish.apply(mediator, args);
 
-  timeout = setTimeout(function() {
-    if (!complete) {
-      cleanUp();
-      deferred.reject(new Error('Mediator request timeout for topic ' +  topic));
-    }
-  }, options.timeout);
-
-  return deferred.promise;
+  return new Promise(function(resolve, reject) {
+    subs.done = mediator.once(topics.done, resolve);
+    subs.error = mediator.once(topics.error, reject);
+  })
+  .timeout(options.timeout, new Error('Mediator request timeout for topic ' +  topic))
+  .tap(unsubscribe)
+  .catch(function(e) {
+    unsubscribe();
+    // still forward the rejection to clients
+    throw e;
+  });
 };
 
 module.exports = mediator;

--- a/lib/topics/index-spec.js
+++ b/lib/topics/index-spec.js
@@ -1,7 +1,7 @@
 const Topics = require('./index');
 const assert = require('assert');
 const mediator = require('../mediator');
-const q = require('q');
+const Promise = require('bluebird');
 
 describe('Topics', function() {
   beforeEach(function() {
@@ -31,7 +31,7 @@ describe('Topics', function() {
     it('should publish a done: event for a successful promise', function(done) {
       this.topics.on('create', function(user) {
         assert.equal(user.id, 'trever');
-        return q(user);
+        return Promise.resolve(user);
       });
       this.topics.onDone('create:trever', function(user) {
         assert.equal(user.id, 'trever');
@@ -42,7 +42,7 @@ describe('Topics', function() {
     it('should use result.id as a uid for request calls', function(done) {
       this.topics.on('create', function(user) {
         assert.equal(user.id, 'trever');
-        return q(user);
+        return Promise.resolve(user);
       });
       this.topics.onDone('create:trever', function(user) {
         assert.equal(user.id, 'trever');
@@ -53,7 +53,7 @@ describe('Topics', function() {
     it('should use result as a uid for request calls if result is a string', function(done) {
       this.topics.on('create', function(user) {
         assert.equal(user.id, 'trever');
-        return q('trever');
+        return Promise.resolve('trever');
       });
       this.topics.onDone('create:trever', function(name) {
         assert.equal(name, 'trever');
@@ -63,7 +63,7 @@ describe('Topics', function() {
     });
     it('should publish an error: event for a unsuccessful promise', function(done) {
       this.topics.on('create', function() {
-        return q.reject(new Error('kaboom'));
+        return Promise.reject(new Error('kaboom'));
       });
       this.topics.onError('create', function(e) {
         assert.equal(e.message, 'kaboom');
@@ -76,7 +76,7 @@ describe('Topics', function() {
         var e = new Error('kaboom');
         // add metadata to error object
         e.id = 'trever';
-        return q.reject(e);
+        return Promise.reject(e);
       });
       this.topics.onError('create:trever', function(e) {
         assert.equal(e.message, 'kaboom');

--- a/lib/topics/index.js
+++ b/lib/topics/index.js
@@ -1,4 +1,4 @@
-const q = require('q');
+const Promise = require('bluebird');
 function Topics(mediator) {
   this.mediator = mediator;
   this.subscriptions = {};
@@ -29,7 +29,7 @@ Topics.prototype.getTopic = function(topicName, prefix) {
 
 function wrapInMediatorPromise(self, method, fn) {
   return function() {
-    q(fn.apply(self, arguments)).then(function(result) {
+    Promise.resolve(fn.apply(self, arguments)).then(function(result) {
       var topic = self.getTopic(method, 'done');
       if (typeof result === 'object' && result.id) {
         topic = [topic, result.id].join(':');

--- a/package.json
+++ b/package.json
@@ -17,13 +17,12 @@
   "dependencies": {
     "lodash": "^4.7.0",
     "mediator-js": "^0.9.9",
-    "q": "^1.4.1",
-    "shortid": "^2.2.6"
+    "shortid": "^2.2.6",
+    "bluebird": "^3.4.7"
   },
   "devDependencies": {
     "angular-node": "^1.3.2",
     "assert": "^1.4.1",
-    "bluebird": "^3.4.7",
     "chai": "^3.5.0",
     "chai-as-promised": "^6.0.0",
     "grunt": "^1.0.1",


### PR DESCRIPTION
We were already using bluebird for the unit tests, let's use it for the rest of the lib, and do some cleanup!

Also defferreds are ugly.

:bird:
ping @JameelB @witmicko @nialldonnellyfh 