### PR TITLE
Warn users when request has no done and error topics assigned.

### DIFF
--- a/lib/mediator.js
+++ b/lib/mediator.js
@@ -67,7 +67,7 @@ Mediator.prototype.request = function(topic, parameters, options) {
   if (uid !== null) {
     topics.done += ':' + uid;
     topics.error += ':' + uid;
-  }else{
+  } else {
     console.error(`Warning: no status topics defined for ${topic}.`);
   }
 

--- a/lib/mediator.js
+++ b/lib/mediator.js
@@ -67,6 +67,8 @@ Mediator.prototype.request = function(topic, parameters, options) {
   if (uid !== null) {
     topics.done += ':' + uid;
     topics.error += ':' + uid;
+  }else{
+    console.error(`Warning: no status topics defined for ${topic}.`);
   }
 
   if (!options.timeout) {


### PR DESCRIPTION
## Motivation

Recently multiple errors were found due to complicated syntax of the request method. 
There are couple variations of the expected parameters that sets uid.

**Note:** Due to missing logger framework this message would be displayed as error. 
Normally it should be warn or info. 

ping @witmicko @TommyJ1994 