### PR TITLE
remove travis nsp checks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ services:
   - docker
 script:
   - npm test
-  - npm run vuln; exit 0
   - bash <(curl https://gist.githubusercontent.com/raincatcher-bot/01ac4cdb3b0770bdb58489dbc17ed6b6/raw/6205a628c3616f6736fd866d5f0fba0a781ec1e4/sonarqube.sh)
 notifications:
   email: false

--- a/lib/topics/index.js
+++ b/lib/topics/index.js
@@ -77,7 +77,7 @@ function wrapInMediatorPromise(self, method, fn) {
       topic = [topic, result].join(':');
     }
     self.mediator.publish(topic, result);
-    return result
+    return result;
   }
 
   function publishError(error) {

--- a/package.json
+++ b/package.json
@@ -5,8 +5,7 @@
   "main": "lib/angular/mediator-ng.js",
   "repository": "https://github.com/feedhenry-raincatcher/raincatcher-mediator",
   "scripts": {
-    "test": "grunt",
-    "vuln": "nsp check"
+    "test": "grunt"
   },
   "keywords": [
     "wfm",
@@ -26,7 +25,6 @@
     "grunt-mocha-test": "^0.13.2",
     "load-grunt-tasks": "^3.5.2",
     "mocha": "^3.2.0",
-    "nsp": "^2.6.2",
     "sinon": "^1.17.7"
   }
 }


### PR DESCRIPTION
**Motivation**
NSP was obsoleted by using snyk for checking vulnerabilities in dependencies. Currently the hack done for it to be an 'optional' check i.e. not fail builds is actually making CI builds that are supposed to fail pass.