### PR TITLE
adds getTopicPromises() & getErrorAndDoneTopicPromises() to mediator

### DIFF
--- a/lib/constants.js
+++ b/lib/constants.js
@@ -1,0 +1,44 @@
+module.exports = {
+  TOPIC_PREFIX: "wfm",
+  USERS_ENTITY_NAME: "users",
+  SYNC_TOPIC_PREFIX: "wfm:sync",
+  STEPS_ENTITY_NAME: "step",
+  WORKORDER_ENTITY_NAME: "workorders",
+  RESULTS_ENTITY_NAME: "results",
+  TOPIC_SEPARATOR: ":",
+  ERROR_PREFIX: "error",
+  DONE_PREFIX: "done",
+  TOPIC_TIMEOUT: 1000,
+  STATUS: {
+    COMPLETE: "complete",
+    COMPLETE_DISPLAY: "Complete",
+    PENDING: "pending",
+    PENDING_DISPLAY: "In Progress",
+    NEW_DISPLAY: "New",
+    UNASSIGNED_DISPLAY: "Unassigned"
+  },
+  STEP_TYPES: {
+    APPFORM: "appform",
+    STATIC: "static"
+  },
+  TOPICS: {
+    CREATE: "create",
+    UPDATE: "update",
+    LIST: "list",
+    REMOVE: "remove",
+    READ: "read",
+    START: "start",
+    STOP: "stop",
+    FORCE_SYNC: "force_sync",
+    SYNC_COMPLETE: "sync_complete",
+    READ_PROFILE: "read_profile"
+  },
+  STEP_TOPICS: {
+    BEGIN: "begin",
+    NEXT: "next",
+    PREVIOUS: "previous",
+    CURRENT: "current",
+    COMPLETE: "complete",
+    SUMMARY: "summary"
+  }
+};

--- a/lib/topics/index-spec.js
+++ b/lib/topics/index-spec.js
@@ -1,5 +1,7 @@
 const Topics = require('./index');
-const assert = require('chai').assert;
+const chai = require('chai');
+chai.use(require('chai-as-promised'));
+const assert = chai.assert;
 const mediator = require('../mediator');
 const Promise = require('bluebird');
 const sinon = require('sinon');
@@ -21,6 +23,13 @@ describe('Topics', function() {
 
     it('should take an optional topic UID', function() {
       assert.equal(this.topics.getTopic('create', 'done', 'topicuid'), 'done:wfm:cloud:user:create:topicuid');
+    });
+  });
+
+  describe('#getErrorAndDoneTopicPromises', function() {
+    // TODO add further tests - return done, error and timeout promises, generate a topUid if none, and re-uses topicUid if already exists
+    it('should return a promise', function() {
+      assert.isDefined(this.topics.getErrorAndDoneTopicPromises('create'));
     });
   });
 

--- a/lib/topics/index.js
+++ b/lib/topics/index.js
@@ -1,5 +1,8 @@
+var q = require('q');
 const Promise = require('bluebird');
 const _ = require('lodash');
+//var shortid = require('shortid');
+
 
 function Topics(mediator) {
   this.mediator = mediator;
@@ -54,6 +57,58 @@ Topics.prototype.getTopic = function(topicName, prefix, topicUid) {
     parts.unshift(prefix);
   }
   return parts.join(':');
+};
+
+/**
+ *
+ * Internal function to get Promises for done and error topics.
+ *
+ * @param doneTopicPromise  - A promise for the done topic.
+ * @param errorTopicPromise - A promise for the error topic.
+ * @returns {*}
+ */
+Topics.prototype.getTopicPromises = function getTopicPromises(doneTopicPromise, errorTopicPromise) {
+  var deferred = q.defer();
+
+  doneTopicPromise.then(function(createdItem) {
+    deferred.resolve(createdItem);
+  });
+
+  errorTopicPromise.then(function(error) {
+    deferred.reject(error);
+  });
+
+  return deferred.promise;
+};
+
+/**
+ *
+ * Internal function to get Promises for done and error topics.
+ *
+ * @param {Object} config - specific config settings (if any)
+ * @param {Object} topicDefaults - topic-specific values for DONE_PREFIX, ERROR_PREFIX, and TOPIC_TIMEOUT
+ * @param {string} topicName   - The name of the topic to generate
+ * @param {string} [topicUid]  - A topic UID if required.
+ * @returns {Promise} - A promise for the topic.
+ */
+Topics.prototype.getErrorAndDoneTopicPromises = function getErrorAndDoneTopicPromises(config, topicDefaults, topicName) {
+  //Creating a unique channel to get the response
+  //var topicUid = shortid.generate();
+
+  var doneTopic = this.getTopic(topicName, topicDefaults.DONE_PREFIX, topicUid);
+  var errorTopic = this.getTopic(topicName, topicDefaults.ERROR_PREFIX, topicUid);
+
+  var doneTopicPromise = this.mediator.promise(doneTopic);
+  var errorTopicPromise = this.mediator.promise(errorTopic);
+
+  var timeoutDefer = q.defer();
+
+  setTimeout(function() {
+    timeoutDefer.reject(new Error("Timeout For Topic: " + doneTopic));
+  }, config.topicTimeout || topicDefaults.TOPIC_TIMEOUT);
+
+  //Either one of these promises resolves/rejects or it will time out.
+  return q.race([this.getTopicPromises(doneTopicPromise, errorTopicPromise), timeoutDefer.promise]);
 };
 
 /**

--- a/lib/topics/index.js
+++ b/lib/topics/index.js
@@ -92,7 +92,10 @@ Topics.prototype.getTopicPromises = function getTopicPromises(doneTopicPromise, 
  */
 Topics.prototype.getErrorAndDoneTopicPromises = function getErrorAndDoneTopicPromises(topicName, config, payload) {
   //Creating a unique channel to get the response
-
+  
+  config = config || {}; // guard against no passed config param
+  payload = payload || {}; // guard against no passed payload param
+  
   var topicUid = payload.topicUid || shortid.generate();
 
   var doneTopic = this.getTopic(topicName, CONSTANTS.DONE_PREFIX, topicUid);
@@ -113,9 +116,16 @@ Topics.prototype.getErrorAndDoneTopicPromises = function getErrorAndDoneTopicPro
 
 
 Topics.prototype.execute = function execute(topicName, config, payload) {
-  if (payload) {
-    payload.topicUid = payload.topicUid || shortid.generate();
-  }
+  
+  /*if (payload) {
+   payload.topicUid = payload.topicUid || shortid.generate();
+   }*/
+  
+  config = config || {}; // guard against no passed config param
+  payload = payload || {}; // guard against no passed payload param
+  
+  payload.topicUid = payload.topicUid || shortid.generate();
+    
   var promise = this.getErrorAndDoneTopicPromises(topicName, config, payload);
   this.mediator.publish(this.getTopic(topicName), payload);
   return promise;

--- a/lib/topics/index.js
+++ b/lib/topics/index.js
@@ -1,8 +1,10 @@
+// TODO Move from Q to bluebird
 var q = require('q');
 const Promise = require('bluebird');
 const _ = require('lodash');
-//var shortid = require('shortid');
 
+// TODO use shortid
+var shortid = require('shortid');
 
 function Topics(mediator) {
   this.mediator = mediator;
@@ -60,7 +62,6 @@ Topics.prototype.getTopic = function(topicName, prefix, topicUid) {
 };
 
 /**
- *
  * Internal function to get Promises for done and error topics.
  *
  * @param doneTopicPromise  - A promise for the done topic.
@@ -91,10 +92,12 @@ Topics.prototype.getTopicPromises = function getTopicPromises(doneTopicPromise, 
  * @param {string} [topicUid]  - A topic UID if required.
  * @returns {Promise} - A promise for the topic.
  */
-Topics.prototype.getErrorAndDoneTopicPromises = function getErrorAndDoneTopicPromises(config, topicDefaults, topicName) {
+Topics.prototype.getErrorAndDoneTopicPromises = function getErrorAndDoneTopicPromises(config, topicName) {
   //Creating a unique channel to get the response
   //var topicUid = shortid.generate();
-
+  // TODO shortid
+  // TODO move done/error prefixes here.
+  // TODO topic defaults as constants in the module
   var doneTopic = this.getTopic(topicName, topicDefaults.DONE_PREFIX, topicUid);
   var errorTopic = this.getTopic(topicName, topicDefaults.ERROR_PREFIX, topicUid);
 
@@ -110,6 +113,26 @@ Topics.prototype.getErrorAndDoneTopicPromises = function getErrorAndDoneTopicPro
   //Either one of these promises resolves/rejects or it will time out.
   return q.race([this.getTopicPromises(doneTopicPromise, errorTopicPromise), timeoutDefer.promise]);
 };
+
+
+Topics.prototype.execute = function getErrorAndDoneTopicPromises(topicName, payload, config) {
+  var promise = this.getErrorAndDoneTopicPromises(config, topicName);
+  this.mediator.publish(this.getTopic(topicName), payload);
+  return promise;
+};
+
+Topics.prototype.handleInMediator = function handleInMediator(topicName, clientMethod, parameters){
+  var workflowListErrorTopic = workflowEntityTopics.getTopic(topicName, CONSTANTS.ERROR_PREFIX, parameters.topicUid);
+  var workflowListDoneTopic = workflowEntityTopics.getTopic(topicName, CONSTANTS.DONE_PREFIX, parameters.topicUid);
+
+  clientMethod(parameters)
+      .then(function(arrayOfWorkflows) {
+        self.mediator.publish(workflowListDoneTopic, arrayOfWorkflows);
+      }).catch(function(error) {
+    self.mediator.publish(workflowListErrorTopic, error);
+  });
+}
+
 
 /**
  * Internal function to wrap a `on` handler in a promise that will publish to the

--- a/lib/topics/index.js
+++ b/lib/topics/index.js
@@ -121,9 +121,9 @@ Topics.prototype.execute = function execute(topicName, config, payload) {
   return promise;
 };
 
-Topics.prototype.handleInMediator = function handleInMediator(topicName, clientMethod, parameters){
-  var workflowListErrorTopic = workflowEntityTopics.getTopic(topicName, CONSTANTS.ERROR_PREFIX, parameters.topicUid);
-  var workflowListDoneTopic = workflowEntityTopics.getTopic(topicName, CONSTANTS.DONE_PREFIX, parameters.topicUid);
+Topics.prototype.handleInMediatore = function handleInMediator(topicName, clientMethod, parameters){
+  var workflowListErrorTopic = this.getTopic(topicName, CONSTANTS.ERROR_PREFIX, parameters.topicUid);
+  var workflowListDoneTopic = this.getTopic(topicName, CONSTANTS.DONE_PREFIX, parameters.topicUid);
 
   clientMethod(parameters)
       .then(function(arrayOfWorkflows) {
@@ -131,7 +131,8 @@ Topics.prototype.handleInMediator = function handleInMediator(topicName, clientM
       }).catch(function(error) {
     self.mediator.publish(workflowListErrorTopic, error);
   });
-}
+
+};
 
 
 /**

--- a/lib/topics/index.js
+++ b/lib/topics/index.js
@@ -121,15 +121,15 @@ Topics.prototype.execute = function execute(topicName, config, payload) {
   return promise;
 };
 
-Topics.prototype.handleInMediatore = function handleInMediator(topicName, clientMethod, parameters){
+Topics.prototype.handleInMediator = function handleInMediator(topicName, clientMethod, parameters) {
   var workflowListErrorTopic = this.getTopic(topicName, CONSTANTS.ERROR_PREFIX, parameters.topicUid);
   var workflowListDoneTopic = this.getTopic(topicName, CONSTANTS.DONE_PREFIX, parameters.topicUid);
 
   clientMethod(parameters)
       .then(function(arrayOfWorkflows) {
-        self.mediator.publish(workflowListDoneTopic, arrayOfWorkflows);
+        clientMethod.mediator.publish(workflowListDoneTopic, arrayOfWorkflows);
       }).catch(function(error) {
-    self.mediator.publish(workflowListErrorTopic, error);
+    clientMethod.mediator.publish(workflowListErrorTopic, error);
   });
 
 };

--- a/lib/topics/index.js
+++ b/lib/topics/index.js
@@ -90,11 +90,10 @@ Topics.prototype.getTopicPromises = function getTopicPromises(doneTopicPromise, 
  * @param {string} topicName   - The name of the topic to generate
  * @returns {Promise} - A promise for the topic.
  */
-Topics.prototype.getErrorAndDoneTopicPromises = function getErrorAndDoneTopicPromises(config, topicName) {
+Topics.prototype.getErrorAndDoneTopicPromises = function getErrorAndDoneTopicPromises(topicName, config, payload) {
   //Creating a unique channel to get the response
-  // TODO move done/error prefixes here.
 
-  var topicUid = shortid.generate();
+  var topicUid = payload.topicUid || shortid.generate();
 
   var doneTopic = this.getTopic(topicName, CONSTANTS.DONE_PREFIX, topicUid);
   var errorTopic = this.getTopic(topicName, CONSTANTS.ERROR_PREFIX, topicUid);
@@ -113,8 +112,11 @@ Topics.prototype.getErrorAndDoneTopicPromises = function getErrorAndDoneTopicPro
 };
 
 
-Topics.prototype.execute = function getErrorAndDoneTopicPromises(topicName, payload, config) {
-  var promise = this.getErrorAndDoneTopicPromises(config, topicName);
+Topics.prototype.execute = function execute(topicName, config, payload) {
+  if (payload) {
+    payload.topicUid = payload.topicUid || shortid.generate();
+  }
+  var promise = this.getErrorAndDoneTopicPromises(topicName, config, payload);
   this.mediator.publish(this.getTopic(topicName), payload);
   return promise;
 };

--- a/lib/topics/index.js
+++ b/lib/topics/index.js
@@ -2,9 +2,9 @@
 var q = require('q');
 const Promise = require('bluebird');
 const _ = require('lodash');
-
-// TODO use shortid
+var CONSTANTS = require('../../constants');
 var shortid = require('shortid');
+
 
 function Topics(mediator) {
   this.mediator = mediator;
@@ -86,20 +86,18 @@ Topics.prototype.getTopicPromises = function getTopicPromises(doneTopicPromise, 
  *
  * Internal function to get Promises for done and error topics.
  *
- * @param {Object} config - specific config settings (if any)
- * @param {Object} topicDefaults - topic-specific values for DONE_PREFIX, ERROR_PREFIX, and TOPIC_TIMEOUT
+ * @param {Object} config - specific config settings such as timeout (if any)
  * @param {string} topicName   - The name of the topic to generate
- * @param {string} [topicUid]  - A topic UID if required.
  * @returns {Promise} - A promise for the topic.
  */
 Topics.prototype.getErrorAndDoneTopicPromises = function getErrorAndDoneTopicPromises(config, topicName) {
   //Creating a unique channel to get the response
-  //var topicUid = shortid.generate();
-  // TODO shortid
   // TODO move done/error prefixes here.
-  // TODO topic defaults as constants in the module
-  var doneTopic = this.getTopic(topicName, topicDefaults.DONE_PREFIX, topicUid);
-  var errorTopic = this.getTopic(topicName, topicDefaults.ERROR_PREFIX, topicUid);
+
+  var topicUid = shortid.generate();
+
+  var doneTopic = this.getTopic(topicName, CONSTANTS.DONE_PREFIX, topicUid);
+  var errorTopic = this.getTopic(topicName, CONSTANTS.ERROR_PREFIX, topicUid);
 
   var doneTopicPromise = this.mediator.promise(doneTopic);
   var errorTopicPromise = this.mediator.promise(errorTopic);
@@ -108,7 +106,7 @@ Topics.prototype.getErrorAndDoneTopicPromises = function getErrorAndDoneTopicPro
 
   setTimeout(function() {
     timeoutDefer.reject(new Error("Timeout For Topic: " + doneTopic));
-  }, config.topicTimeout || topicDefaults.TOPIC_TIMEOUT);
+  }, config.topicTimeout || CONSTANTS.TOPIC_TIMEOUT);
 
   //Either one of these promises resolves/rejects or it will time out.
   return q.race([this.getTopicPromises(doneTopicPromise, errorTopicPromise), timeoutDefer.promise]);

--- a/lib/topics/index.js
+++ b/lib/topics/index.js
@@ -2,7 +2,7 @@
 var q = require('q');
 const Promise = require('bluebird');
 const _ = require('lodash');
-var CONSTANTS = require('../../constants');
+var CONSTANTS = require('../constants');
 var shortid = require('shortid');
 
 

--- a/lib/topics/index.js
+++ b/lib/topics/index.js
@@ -92,10 +92,9 @@ Topics.prototype.getTopicPromises = function getTopicPromises(doneTopicPromise, 
  */
 Topics.prototype.getErrorAndDoneTopicPromises = function getErrorAndDoneTopicPromises(topicName, config, payload) {
   //Creating a unique channel to get the response
-  
   config = config || {}; // guard against no passed config param
   payload = payload || {}; // guard against no passed payload param
-  
+
   var topicUid = payload.topicUid || shortid.generate();
 
   var doneTopic = this.getTopic(topicName, CONSTANTS.DONE_PREFIX, topicUid);
@@ -116,16 +115,12 @@ Topics.prototype.getErrorAndDoneTopicPromises = function getErrorAndDoneTopicPro
 
 
 Topics.prototype.execute = function execute(topicName, config, payload) {
-  
-  /*if (payload) {
-   payload.topicUid = payload.topicUid || shortid.generate();
-   }*/
-  
+
   config = config || {}; // guard against no passed config param
   payload = payload || {}; // guard against no passed payload param
-  
+
   payload.topicUid = payload.topicUid || shortid.generate();
-    
+
   var promise = this.getErrorAndDoneTopicPromises(topicName, config, payload);
   this.mediator.publish(this.getTopic(topicName), payload);
   return promise;
@@ -139,9 +134,8 @@ Topics.prototype.handleInMediator = function handleInMediator(topicName, clientM
       .then(function(arrayOfWorkflows) {
         clientMethod.mediator.publish(workflowListDoneTopic, arrayOfWorkflows);
       }).catch(function(error) {
-    clientMethod.mediator.publish(workflowListErrorTopic, error);
-  });
-
+        clientMethod.mediator.publish(workflowListErrorTopic, error);
+      });
 };
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-wfm-mediator",
-  "version": "0.4.0",
+  "version": "0.4.0-alpha.629.1",
   "description": "An implementation of the mediator pattern for use with WFM",
   "main": "lib/angular/mediator-ng.js",
   "repository": "https://github.com/feedhenry-raincatcher/raincatcher-mediator",
@@ -11,7 +11,7 @@
     "wfm",
     "mediator"
   ],
-  "author": "Brian Leathem",
+  "author": "feedhenry-raincatcher@redhat.com",
   "license": "MIT",
   "dependencies": {
     "lodash": "^4.7.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-wfm-mediator",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "description": "An implementation of the mediator pattern for use with WFM",
   "main": "lib/angular/mediator-ng.js",
   "repository": "https://github.com/feedhenry-raincatcher/raincatcher-mediator",
@@ -15,6 +15,7 @@
   "license": "MIT",
   "dependencies": {
     "lodash": "^4.7.0",
+    "q": "1.4.1",
     "mediator-js": "^0.9.9",
     "bluebird": "^3.4.7"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-wfm-mediator",
-  "version": "0.4.0-alpha.629.3",
+  "version": "0.4.0-alpha.629.4",
   "description": "An implementation of the mediator pattern for use with WFM",
   "main": "lib/angular/mediator-ng.js",
   "repository": "https://github.com/feedhenry-raincatcher/raincatcher-mediator",
@@ -14,14 +14,15 @@
   "author": "feedhenry-raincatcher@redhat.com",
   "license": "MIT",
   "dependencies": {
-    "lodash": "^4.7.0",
-    "q": "1.4.1",
-    "mediator-js": "^0.9.9",
     "bluebird": "^3.4.7",
+    "lodash": "^4.7.0",
+    "mediator-js": "^0.9.9",
+    "q": "1.4.1",
     "shortid": "2.2.6"
   },
   "devDependencies": {
     "chai": "^3.5.0",
+    "chai-as-promised": "^6.0.0",
     "grunt": "^1.0.1",
     "grunt-eslint": "18.0.0",
     "grunt-mocha-test": "^0.13.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-wfm-mediator",
-  "version": "0.4.0-alpha.629.2",
+  "version": "0.4.0-alpha.629.3",
   "description": "An implementation of the mediator pattern for use with WFM",
   "main": "lib/angular/mediator-ng.js",
   "repository": "https://github.com/feedhenry-raincatcher/raincatcher-mediator",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-wfm-mediator",
-  "version": "0.4.0-alpha.629.1",
+  "version": "0.4.0-alpha.629.2",
   "description": "An implementation of the mediator pattern for use with WFM",
   "main": "lib/angular/mediator-ng.js",
   "repository": "https://github.com/feedhenry-raincatcher/raincatcher-mediator",
@@ -17,7 +17,8 @@
     "lodash": "^4.7.0",
     "q": "1.4.1",
     "mediator-js": "^0.9.9",
-    "bluebird": "^3.4.7"
+    "bluebird": "^3.4.7",
+    "shortid": "2.2.6"
   },
   "devDependencies": {
     "chai": "^3.5.0",

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,7 +1,7 @@
 sonar.host.url=https://sonarqube.com
 sonar.projectKey=raincatcher-mediator
 sonar.projectName=raincatcher-mediator
-sonar.projectVersion=0.0.14
+sonar.projectVersion=0.4.0
 
 sonar.sources=./lib
 sonar.language=js


### PR DESCRIPTION
moves getTopicPromises() and getErrorAndDoneTopicPromises() into mediator & bumps version num

part of https://issues.jboss.org/browse/RAINCATCH-629 which involved refactoring raincatcher-workorder and raincatcher-workflow to remove the getTopicPromises() and getErrorAndDoneTopicPromises() functionality in them, and move them into the mediator instead

related prs: 
https://github.com/feedhenry-raincatcher/raincatcher-workorder/pull/23
https://github.com/feedhenry-raincatcher/raincatcher-workflow/pull/19
