### PR TITLE
🚑 Fix memory leak in unsubscribe

### DIFF
--- a/lib/mediator.js
+++ b/lib/mediator.js
@@ -76,8 +76,8 @@ Mediator.prototype.request = function(topic, parameters, options) {
   }
 
   function unsubscribe() {
-    self.remove(topics.done, subs.done);
-    self.remove(topics.error, subs.error);
+    self.remove(topics.done, subs.done.id);
+    self.remove(topics.error, subs.error.id);
   }
 
   var args = [topics.request];


### PR DESCRIPTION
JIRA: https://issues.jboss.org/browse/RAINCATCH-646

In this JIRA issue, we identified that there was a memory leak. We then had trouble reproducing it with just the demo data. With more data (workorders/results/workflows/messages) it's much clearer.

The problem was that the `subs.done` and `subs.error` that are assigned here from calls to `self.once`, are objects, where the `self.remove` call expects a string as the second parameter. Mediator-js compares that with another string, and removes the channel if they match (they obviously don't match if they're not the same type).

Passing the 'id' property seems to be what `self.remove` expects, and memory usage graphs show that with this fix, the usage is more stable.