### PR TITLE
🕓 Increase the default timeout value to 1 minute

### DIFF
--- a/lib/mediator.js
+++ b/lib/mediator.js
@@ -72,7 +72,7 @@ Mediator.prototype.request = function(topic, parameters, options) {
   }
 
   if (!options.timeout) {
-    options.timeout = 2000;
+    options.timeout = 60000;
   }
 
   function unsubscribe() {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-wfm-mediator",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "An implementation of the mediator pattern for use with WFM",
   "main": "lib/angular/mediator-ng.js",
   "repository": "https://github.com/feedhenry-raincatcher/raincatcher-mediator",


### PR DESCRIPTION
In RAINCATCH-619[1], we noticed that with high concurrency, sometimes the 2 seconds is not enough, now that the data is persisted in MongoDB, and the Error is returned for the topic, even though it might eventually complete successfully.

I'm not sure what the actual value should be, but local tests indicate that increasing the value here helps. I'm not sure if there could be any negative knock-on effect of setting it too high? Does anyone have an idea of what the default here should be?

[1] https://issues.jboss.org/browse/RAINCATCH-619