### PR TITLE
Expose mediator topics utility to top level

### DIFF
--- a/lib/mediator.js
+++ b/lib/mediator.js
@@ -104,4 +104,5 @@ Mediator.prototype.request = function(topic, parameters, options) {
 
 var mediator = new Mediator();
 mediator.Mediator = Mediator;
+mediator.Topics  = require("./topics");
 module.exports = mediator;

--- a/lib/mediator.js
+++ b/lib/mediator.js
@@ -102,7 +102,9 @@ Mediator.prototype.request = function(topic, parameters, options) {
   });
 };
 
+// Exposing topics utility
+Mediator.prototype.Topics = require("./topics");
+
 var mediator = new Mediator();
 mediator.Mediator = Mediator;
-mediator.Topics  = require("./topics");
 module.exports = mediator;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-wfm-mediator",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "description": "An implementation of the mediator pattern for use with WFM",
   "main": "lib/angular/mediator-ng.js",
   "repository": "https://github.com/feedhenry-raincatcher/raincatcher-mediator",


### PR DESCRIPTION
## Motivation

Expose mediator topics utility to be available as part of the mediator singleton. 
This would allow us to remove mediator dependency from all modules. 

ping @grdryn @paolobueno 