### PR TITLE
Improve performance of the Topics utility

### DIFF
--- a/lib/topics/index.js
+++ b/lib/topics/index.js
@@ -14,6 +14,7 @@ function Topics(mediator) {
  */
 Topics.prototype.prefix = function(prefix) {
   this.prefix = prefix;
+  this.fullPrefix = prefix;
   return this;
 };
 
@@ -27,6 +28,7 @@ Topics.prototype.prefix = function(prefix) {
  */
 Topics.prototype.entity = function(entity) {
   this.entity = entity;
+  this.fullPrefix = this.prefix + ':' + this.entity;
   return this;
 };
 
@@ -48,13 +50,46 @@ Topics.prototype.addSubscription = function(topic, fn) {
  *                              i.e. {prefix}:{this.prefix}:{this.entity}:{topicName}:{topicUid}
  */
 Topics.prototype.getTopic = function(topicName, prefix, topicUid) {
-  // create, done => done:wfm:user:create
-  var parts = _.compact([this.prefix, this.entity, topicName, topicUid]);
+  // (create, done, 1) => done:wfm:user:create:1
+  var topic = this.fullPrefix;
   if (prefix) {
-    parts.unshift(prefix);
+    topic = prefix + ':' + topic;
   }
-  return parts.join(':');
+  if (topicName) {
+    topic += ':' + topicName;
+  }
+  if (topicUid) {
+    topic += ':' + topicUid;
+  }
+  return topic;
 };
+
+function buildDonePublishFn(mediator, topic) {
+  return function(result) {
+    if (_.isUndefined(result)) {
+      return;
+    }
+
+    topic = 'done:' + topic;
+    if (typeof result === 'string') {
+      topic = topic + ':' + result;
+    } else if (_.has(result, 'id')) {
+      topic = topic + ':' + result.id;
+    }
+    mediator.publish(topic, result);
+    return result;
+  };
+}
+
+function buildErrorPublishFn(mediator, topic) {
+  return function(error) {
+    topic = 'error:' + topic;
+    if (_.has(error, 'id')) {
+      topic = topic + ':' + error.id;
+    }
+    mediator.publish(topic, error);
+  };
+}
 
 /**
  * Internal function to wrap a `on` handler in a promise that will publish to the
@@ -66,33 +101,10 @@ Topics.prototype.getTopic = function(topicName, prefix, topicUid) {
  * @return {Function}        Wrapped handler
  */
 function wrapInMediatorPromise(self, method, fn) {
-  function publishDone(result) {
-    if (_.isUndefined(result)) {
-      return;
-    }
-
-    var topic = self.getTopic(method, 'done');
-    if (_.has(result, 'id')) {
-      topic = [topic, result.id].join(':');
-    } else if (typeof result === 'string') {
-      topic = [topic, result].join(':');
-    }
-    self.mediator.publish(topic, result);
-    return result;
-  }
-
-  function publishError(error) {
-    var topic = self.getTopic(method, 'error');
-    if (_.has(error, 'id')) {
-      topic = [topic, error.id].join(':');
-    }
-    self.mediator.publish(topic, error);
-  }
-
   return function() {
     return Promise.resolve(fn.apply(self, arguments))
-      .then(publishDone)
-      .catch(publishError);
+      .then(buildDonePublishFn(self.mediator, self.getTopic(method)))
+      .catch(buildErrorPublishFn(self.mediator, self.getTopic));
   };
 }
 


### PR DESCRIPTION
### Motivation
Running the new benchmark files separately leads to a much larger time for execution of mediator requests via the lib/Topics util.

### Changes
Remove Array.join() operations in favor of string concatenation, cache configured prefixes.

WIP, tests not passing